### PR TITLE
fixing the conversion from std to boost

### DIFF
--- a/include/MotionPlanner.h
+++ b/include/MotionPlanner.h
@@ -113,7 +113,6 @@ class Planning{
 
     int maxWidth_;
     int maxHeight_;
-    og::SimpleSetupPtr ss_;
-
+    boost::shared_ptr<og::SimpleSetup> ss_;
 };
 #endif

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -200,17 +200,14 @@ bool Planning::isStateValid(const ob::State *state) const {
 
 void Planning::planSimple(){
   //if throwing an error related to shared pointer conflict b/w boost and std, uncomment the follwing line and comment the 2nd one.
-  // boost::shared_ptr<ob::RealVectorStateSpace> space(boost::make_shared<ob::RealVectorStateSpace>());
-  auto space(std::make_shared<ob::RealVectorStateSpace>());
+  std::shared_ptr<ob::RealVectorStateSpace> space(std::make_shared<ob::RealVectorStateSpace>());
 
   space->addDimension(0.0, 800.0);
   space->addDimension(0.0, 800.0);
   maxWidth_ = 800-1;
   maxHeight_ = 800-1;
 
-  //do the same here too.
-  // ss_ = boost::make_shared<og::SimpleSetup>(space);
-  ss_ = std::make_shared<og::SimpleSetup>(space);
+  ss_ = boost::make_shared<og::SimpleSetup>(space);
 
   ss_->setStateValidityChecker([this](const ob::State *state) {return isStateValid(state);});
   space->setup();


### PR DESCRIPTION
Hopefully the final fix on boost to std and vice versa conversions for `ompl`